### PR TITLE
babel polyfill import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-require('babel-polyfill')
+import 'babel-polyfill'
 import ReactDOM from 'react-dom'
 import React from 'react'
 import {


### PR DESCRIPTION
why old syntax?
